### PR TITLE
Relax minitest dependency

### DIFF
--- a/minitest-context.gemspec
+++ b/minitest-context.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "minitest", '~> 5.8'
+  spec.add_dependency "minitest", '>= 5.8'
 end


### PR DESCRIPTION
Allow us to use the gem with any recent minitest version.

If it ever doesnt work with a minitest version, then users of the gem will submit PR's

Without this the gem dies :(